### PR TITLE
Test scores schoolpage

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -344,3 +344,30 @@
   font-weight: bold;
   margin-right: 0.5rem;
 }
+
+.custom-tooltip {
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 5px;
+  position: relative;
+  text-align: center;
+  border: none;
+}
+
+.tooltip-pointer {
+  border: solid transparent;
+  border-width: 8px;
+  height: 0;
+  position: absolute;
+  width: 0;
+  bottom: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-top-color: rgba(0, 0, 0, 0.8);
+}
+
+.custom-tooltip p {
+  margin: 0;
+  font-size: 12px;
+  color: white;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -315,3 +315,32 @@
   text-decoration: underline;
   background-color: transparent;
 }
+
+.score-bar-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.score-bar {
+  width: 40%;
+  height: 1.5rem;
+  margin-right: 1rem;
+  background-color: #f5f5f5;
+  position: relative;
+}
+
+.score-bar-filled {
+  position: absolute;
+  height: 100%;
+  left: 0;
+  top: 0;
+  background-color: #8BC34A;
+  transition: width 0.5s;
+}
+
+.score-bar-text {
+  font-size: 1rem;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}

--- a/frontend/src/components/HorizontalScoreBar.jsx
+++ b/frontend/src/components/HorizontalScoreBar.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from 'recharts';
+
+const HorizontalSchoolBar = ({ value }) => {
+
+  const data = [
+    {
+      value: value,
+    }
+  ];
+
+  return (
+    <ResponsiveContainer width="90%" height={30}>
+      <BarChart
+        data={data}
+        margin={{
+          top: 0,
+          right: 0,
+          left: 0,
+          bottom: 0,
+        }}
+        layout="vertical"
+      >
+        <XAxis type="number" domain={[0, 100]} hide />
+        <YAxis type="category" dataKey="name" hide />
+        <CartesianGrid stroke="#f5f5f5" fill="#f5f5f5" vertical={false} />
+        <Bar dataKey="value" fill="#8BC34A" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default HorizontalSchoolBar;

--- a/frontend/src/components/HorizontalScoreBar.jsx
+++ b/frontend/src/components/HorizontalScoreBar.jsx
@@ -36,7 +36,7 @@ const HorizontalScoreBar = ({ examName, value }) => {
                         >
                             <XAxis type="number" domain={[0, 100]} hide />
                             <YAxis type="category" dataKey="examName" hide />
-                            <CartesianGrid stroke="#f5f5f5" fill="#f5f5f5" vertical={false} />
+                            <CartesianGrid stroke="#f0f0f0" fill="#f0f0f0" vertical={false} />
                             <Bar dataKey="value" fill="#8BC34A" />
                         </BarChart>
                     </ResponsiveContainer>

--- a/frontend/src/components/HorizontalScoreBar.jsx
+++ b/frontend/src/components/HorizontalScoreBar.jsx
@@ -1,33 +1,49 @@
 import React from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from 'recharts';
+import { TableCell, TableRow } from '@mui/material';
+import {
+    Box,
+    Typography,
+  } from "@mui/material";
 
-const HorizontalSchoolBar = ({ value }) => {
+const HorizontalScoreBar = ({ examName, value }) => {
 
   const data = [
     {
+      examName: examName,
       value: value,
     }
-  ];
+    ];
 
-  return (
-    <ResponsiveContainer width="90%" height={30}>
-      <BarChart
-        data={data}
-        margin={{
-          top: 0,
-          right: 0,
-          left: 0,
-          bottom: 0,
-        }}
-        layout="vertical"
-      >
-        <XAxis type="number" domain={[0, 100]} hide />
-        <YAxis type="category" dataKey="name" hide />
-        <CartesianGrid stroke="#f5f5f5" fill="#f5f5f5" vertical={false} />
-        <Bar dataKey="value" fill="#8BC34A" />
-      </BarChart>
-    </ResponsiveContainer>
-  );
+    return (
+        <TableRow>
+            <TableCell sx={{ border: 'none' }} width="40%">
+                <Typography variant="body1">{examName}</Typography>
+            </TableCell>
+            <TableCell sx={{ border: 'none' }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <Typography variant="body1" fontWeight="600">{Math.round(value)}%</Typography>
+                    <ResponsiveContainer width="90%" height={30}>
+                        <BarChart
+                            data={data}
+                            margin={{
+                                top: 0,
+                                right: 0,
+                                left: 0,
+                                bottom: 0,
+                            }}
+                            layout="vertical"
+                        >
+                            <XAxis type="number" domain={[0, 100]} hide />
+                            <YAxis type="category" dataKey="examName" hide />
+                            <CartesianGrid stroke="#f5f5f5" fill="#f5f5f5" vertical={false} />
+                            <Bar dataKey="value" fill="#8BC34A" />
+                        </BarChart>
+                    </ResponsiveContainer>
+                </Box>
+            </TableCell>
+        </TableRow>
+    );
 };
 
-export default HorizontalSchoolBar;
+export default HorizontalScoreBar;

--- a/frontend/src/components/HorizontalScoreBar.jsx
+++ b/frontend/src/components/HorizontalScoreBar.jsx
@@ -4,16 +4,30 @@ import { TableCell, TableRow } from '@mui/material';
 import {
     Box,
     Typography,
-  } from "@mui/material";
+} from "@mui/material";
 
-const HorizontalScoreBar = ({ examName, value }) => {
+const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
 
-  const data = [
-    {
-      examName: examName,
-      value: value,
-    }
+    const data = [
+        {
+            examName: examName,
+            value: value,
+            stateAverage: stateAverage
+        }
     ];
+
+     const getBarColor = () => {
+        const difference = value - stateAverage;
+        if(difference <= -15){
+            return "#FF0000"; //red
+        } else if(difference < 0){
+            return "#FFC107"; //yellow
+        } else if(difference <= 15){
+            return "#8BC34A"; //light green
+        } else{
+            return "#388E3C"; //darker green
+        }
+     };
 
     return (
         <TableRow>
@@ -37,7 +51,7 @@ const HorizontalScoreBar = ({ examName, value }) => {
                             <XAxis type="number" domain={[0, 100]} hide />
                             <YAxis type="category" dataKey="examName" hide />
                             <CartesianGrid stroke="#f0f0f0" fill="#f0f0f0" vertical={false} />
-                            <Bar dataKey="value" fill="#8BC34A" />
+                            <Bar dataKey="value" fill={getBarColor(value, stateAverage)} />
                         </BarChart>
                     </ResponsiveContainer>
                 </Box>

--- a/frontend/src/components/HorizontalScoreBar.jsx
+++ b/frontend/src/components/HorizontalScoreBar.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, Tooltip } from 'recharts';
 import { TableCell, TableRow } from '@mui/material';
 import {
@@ -15,8 +15,46 @@ const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
         }
     ];
 
+    const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+    
 
-     const getBarColor = ( value, stateAverage) => {
+    useEffect(() => {
+        const handleResize = () => setScreenWidth(window.innerWidth);
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    const tooltipScalingFactor = useMemo(() => {
+        if (screenWidth >= 1170) {
+            return 3.1;
+        } else if (screenWidth >= 1124) {
+            return 3;
+        } else if (screenWidth >= 1040) {
+            return 2.5;
+        } else if (screenWidth >= 1000) {
+            return 2.3;
+        } else if (screenWidth >= 900) {
+            return 2;
+        } else if (screenWidth >= 850) {
+            return 3.5;
+        } else if (screenWidth >= 800) {
+            return 3;
+        } else if (screenWidth >= 750) {
+            return 2.8;
+        } else if (screenWidth >= 700) {
+            return 2.5;
+        } else if (screenWidth >= 650) {
+            return 2.3;
+        } else if (screenWidth >= 600) {
+            return 2.2;
+        } else if (screenWidth >= 500) {
+            return 2.2;
+        } else {
+            return 2;
+        }
+    }, [screenWidth]);
+
+    const getBarColor = (value, stateAverage) => {
         const difference = value - stateAverage;
         if(difference <= -15){
             return "#FF0000"; //red
@@ -64,7 +102,7 @@ const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
                                 <Tooltip
                                     wrapperStyle={{ outline: "none" }}
                                     content={<CustomTooltip />}
-                                    position={{ x: stateAverage * 3, y: -38 }}
+                                    position={{ x: stateAverage * tooltipScalingFactor, y: -38 }}
                                 />
                             )}
                             <Bar dataKey="value" fill={getBarColor(value, stateAverage)} />

--- a/frontend/src/components/HorizontalScoreBar.jsx
+++ b/frontend/src/components/HorizontalScoreBar.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from 'recharts';
+import React, { useRef } from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, Tooltip } from 'recharts';
 import { TableCell, TableRow } from '@mui/material';
 import {
     Box,
@@ -7,7 +7,6 @@ import {
 } from "@mui/material";
 
 const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
-
     const data = [
         {
             examName: examName,
@@ -16,7 +15,8 @@ const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
         }
     ];
 
-     const getBarColor = () => {
+
+     const getBarColor = ( value, stateAverage) => {
         const difference = value - stateAverage;
         if(difference <= -15){
             return "#FF0000"; //red
@@ -24,10 +24,19 @@ const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
             return "#FFC107"; //yellow
         } else if(difference <= 15){
             return "#8BC34A"; //light green
-        } else{
+        } else {
             return "#388E3C"; //darker green
         }
-     };
+    };
+
+    const CustomTooltip = () => {
+        return (
+            <div className="custom-tooltip">
+                <p>{`State Average: ${stateAverage}%`}</p>
+                <div className="tooltip-pointer"></div>
+            </div>
+        );
+    };
 
     return (
         <TableRow>
@@ -37,7 +46,7 @@ const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
             <TableCell sx={{ border: 'none' }}>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <Typography variant="body1" fontWeight="600">{Math.round(value)}%</Typography>
-                    <ResponsiveContainer width="90%" height={30}>
+                    <ResponsiveContainer width="90%" height={30} >
                         <BarChart
                             data={data}
                             margin={{
@@ -51,6 +60,13 @@ const HorizontalScoreBar = ({ examName, value, stateAverage }) => {
                             <XAxis type="number" domain={[0, 100]} hide />
                             <YAxis type="category" dataKey="examName" hide />
                             <CartesianGrid stroke="#f0f0f0" fill="#f0f0f0" vertical={false} />
+                            {stateAverage && (
+                                <Tooltip
+                                    wrapperStyle={{ outline: "none" }}
+                                    content={<CustomTooltip />}
+                                    position={{ x: stateAverage * 3, y: -38 }}
+                                />
+                            )}
                             <Bar dataKey="value" fill={getBarColor(value, stateAverage)} />
                         </BarChart>
                     </ResponsiveContainer>

--- a/frontend/src/components/LiveSearch.jsx
+++ b/frontend/src/components/LiveSearch.jsx
@@ -14,7 +14,8 @@ function LiveSearch() {
   
   const handleSchoolSelection = (event, value) => {
     setSelectedSchool(value);
-    navigate(`/school/${value.school_name}`, {state: {school: value} });
+    const encodedSchoolName = encodeURIComponent(value.school_name);
+    navigate(`/school/${encodedSchoolName}`, { state: { school: value } });
   }
   return (
     <Stack

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -51,7 +51,7 @@ import { SiMoleculer } from 'react-icons/si/index.js';
 import { GoComment } from 'react-icons/go/index.js';
 
 import HorizontalScoreBar from "../HorizontalScoreBar";
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import { Table, TableBody} from '@mui/material';
 
 function SchoolpageView() {
   const location = useLocation();
@@ -848,7 +848,7 @@ function SchoolpageView() {
                 )}
               </List>
             </Box>
-{/*Test Scores*/}
+            {/*Test Scores*/}
             <Box id="aca-testscores" className="middle-container academics">
               <h3>Academics</h3>
               <h2>Test Scores</h2>
@@ -856,125 +856,16 @@ function SchoolpageView() {
               <Box sx={{ width: "100%" }}>
                 <Table>
                   <TableBody>
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Algebra I</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(algebraMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(algebraMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Algebra II</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(algebra2MeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(algebra2MeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Geometry</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(geometryMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(geometryMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">English</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(englishMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(englishMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Global History</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(globalhistoryMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(globalhistoryMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">U.S. History</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(USHistoryMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(USHistoryMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Living Environment</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(livingEnvironMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(livingEnvironMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Earth Science</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(earthScienceMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(earthScienceMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Chemistry</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(chemistryMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(chemistryMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    <TableRow>
-                      <TableCell sx={{ border: 'none' }} width="40%">
-                        <Typography variant="body1">Physics</Typography>
-                      </TableCell>
-                      <TableCell sx={{ border: 'none' }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                          <Typography variant="body1" fontWeight="600">{Math.round(physicsMeanScore)}%</Typography>
-                          <HorizontalScoreBar value={Math.round(physicsMeanScore)} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
+                    <HorizontalScoreBar examName="Algebra I" value={Math.round(algebraMeanScore)} />
+                    <HorizontalScoreBar examName="Algebra II" value={Math.round(algebra2MeanScore)} />
+                    <HorizontalScoreBar examName="Geometry" value={Math.round(geometryMeanScore)} />
+                    <HorizontalScoreBar examName="English" value={Math.round(englishMeanScore)} />
+                    <HorizontalScoreBar examName="Global History" value={Math.round(globalhistoryMeanScore)} />
+                    <HorizontalScoreBar examName="U.S. History" value={Math.round(USHistoryMeanScore)} />
+                    <HorizontalScoreBar examName="Living Environment" value={Math.round(livingEnvironMeanScore)} />
+                    <HorizontalScoreBar examName="Earth Science" value={Math.round(earthScienceMeanScore)} />
+                    <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} />
+                    <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} />
                   </TableBody>
                 </Table>
               </Box>
@@ -982,10 +873,10 @@ function SchoolpageView() {
           </Box>
         </Grid>
         <Tooltip title="Save School">
-          <IconButton sx={{ 
-            position: "fixed", 
-            bottom: 0, 
-            right: 0, 
+          <IconButton sx={{
+            position: "fixed",
+            bottom: 0,
+            right: 0,
             backgroundColor: "#f1f1f1", 
             borderRadius: "50%", 
             m: 5,

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -305,7 +305,6 @@ function SchoolpageView() {
 
   const algebraRegentsScores = testScores.filter(score => {
     return score.regents_exam === "Common Core Algebra" &&
-      
       score.category === "English Proficient";
   });
   const algebraMeanScore = algebraRegentsScores[0]?.mean_score;
@@ -363,6 +362,32 @@ function SchoolpageView() {
       score.category === "English Proficient";
   });
   const USHistoryMeanScore = USHistoryRegentsScores[0]?.mean_score;
+
+  const spanishRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Spanish" &&
+      score.category === "English Proficient";
+  });
+  const spanishMeanScore = spanishRegentsScores[0]?.mean_score;
+
+  const frenchRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "French" &&
+      score.category === "English Proficient";
+  });
+  const frenchMeanScore = frenchRegentsScores[0]?.mean_score;
+
+  const chineseRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Chinese" &&
+      score.category === "English Proficient";
+  });
+  const chineseMeanScore = chineseRegentsScores[0]?.mean_score;
+
+  const italianRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Italian" &&
+      score.category === "English Proficient";
+  });
+  const italianMeanScore = italianRegentsScores[0]?.mean_score;
+
+
 
   return (
     <>
@@ -889,6 +914,26 @@ function SchoolpageView() {
                   </TableBody>
                 </Table>
               </Box>
+              <h4>Language (LOTE) Exams</h4>
+              <Box sx={{ width: "100%" }}>
+                <Table>
+                  <TableBody>
+                    {spanishMeanScore && spanishMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Spanish" value={Math.round(spanishMeanScore)} />
+                    }
+                    {frenchMeanScore && frenchMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="French" value={Math.round(frenchMeanScore)} />
+                    }
+                    {italianMeanScore && italianMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Italian" value={Math.round(italianMeanScore)} />
+                    }
+                    {chineseMeanScore && chineseMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Chinese" value={Math.round(chineseMeanScore)} />
+                    }
+                  </TableBody>
+                </Table>
+              </Box>
+
             </Box>
           </Box>
         </Grid>

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -856,16 +856,36 @@ function SchoolpageView() {
               <Box sx={{ width: "100%" }}>
                 <Table>
                   <TableBody>
-                    <HorizontalScoreBar examName="Algebra I" value={Math.round(algebraMeanScore)} />
-                    <HorizontalScoreBar examName="Algebra II" value={Math.round(algebra2MeanScore)} />
-                    <HorizontalScoreBar examName="Geometry" value={Math.round(geometryMeanScore)} />
-                    <HorizontalScoreBar examName="English" value={Math.round(englishMeanScore)} />
-                    <HorizontalScoreBar examName="Global History" value={Math.round(globalhistoryMeanScore)} />
-                    <HorizontalScoreBar examName="U.S. History" value={Math.round(USHistoryMeanScore)} />
-                    <HorizontalScoreBar examName="Living Environment" value={Math.round(livingEnvironMeanScore)} />
-                    <HorizontalScoreBar examName="Earth Science" value={Math.round(earthScienceMeanScore)} />
-                    <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} />
-                    <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} />
+                    {algebraMeanScore && algebraMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Algebra I" value={Math.round(algebraMeanScore)} />
+                    }
+                    {algebra2MeanScore && algebra2MeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Algebra II" value={Math.round(algebra2MeanScore)} />
+                    }
+                    {geometryMeanScore && geometryMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Geometry" value={Math.round(geometryMeanScore)} />
+                    }
+                    {englishMeanScore && englishMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="English" value={Math.round(englishMeanScore)} />
+                    }
+                    {globalhistoryMeanScore && globalhistoryMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Global History" value={Math.round(globalhistoryMeanScore)} />
+                    }
+                    {USHistoryMeanScore && USHistoryMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="U.S. History" value={Math.round(USHistoryMeanScore)} />
+                    }
+                    {livingEnvironMeanScore && livingEnvironMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Living Environment" value={Math.round(livingEnvironMeanScore)} />
+                    }
+                    {earthScienceMeanScore && earthScienceMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Earth Science" value={Math.round(earthScienceMeanScore)} />
+                    }
+                    {chemistryMeanScore && chemistryMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} />
+                    }
+                    {physicsMeanScore && physicsMeanScore !== "s" &&
+                      <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} />
+                    }
                   </TableBody>
                 </Table>
               </Box>

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -50,6 +50,9 @@ import { FaMoneyBillWave, FaPiedPiperHat } from 'react-icons/fa/index.js';
 import { SiMoleculer } from 'react-icons/si/index.js';
 import { GoComment } from 'react-icons/go/index.js';
 
+import HorizontalScoreBar from "../HorizontalScoreBar";
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+
 function SchoolpageView() {
   const location = useLocation();
   const school = location.state.school;
@@ -850,18 +853,132 @@ function SchoolpageView() {
               <h3>Academics</h3>
               <h2>Test Scores</h2>
               <h4>Regents Exams</h4>
-              <p>Algebra I:  {algebraMeanScore}</p>
-              <p>Algebra II: {algebra2MeanScore} </p>
-              <p>English: {englishMeanScore} </p>
-              <p>Geometry: {geometryMeanScore} </p>
-              <p>Global History: {globalhistoryMeanScore} </p>
-              <p>U.S. History: {USHistoryMeanScore}</p>
-              <p>Living Environment:  {livingEnvironMeanScore}</p>
-              <p>Earth Science: {earthScienceMeanScore} </p>
-              <p>Chemistry: {chemistryMeanScore} </p>
-              <p>Physics: {physicsMeanScore} </p>
-            </Box>
+              <Box sx={{ width: "100%" }}>
+                <Table>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Algebra I</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(algebraMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(algebraMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
 
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Algebra II</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(algebra2MeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(algebra2MeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Geometry</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(geometryMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(geometryMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">English</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(englishMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(englishMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Global History</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(globalhistoryMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(globalhistoryMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">U.S. History</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(USHistoryMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(USHistoryMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Living Environment</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(livingEnvironMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(livingEnvironMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Earth Science</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(earthScienceMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(earthScienceMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Chemistry</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(chemistryMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(chemistryMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell sx={{ border: 'none' }} width="40%">
+                        <Typography variant="body1">Physics</Typography>
+                      </TableCell>
+                      <TableCell sx={{ border: 'none' }}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <Typography variant="body1" fontWeight="600">{Math.round(physicsMeanScore)}%</Typography>
+                          <HorizontalScoreBar value={Math.round(physicsMeanScore)} />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </Box>
+            </Box>
           </Box>
         </Grid>
         <Tooltip title="Save School">

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -53,7 +53,6 @@ import { GoComment } from 'react-icons/go/index.js';
 function SchoolpageView() {
   const location = useLocation();
   const school = location.state.school;
-  console.log(school);
   const latitude = Number(school?.latitude);
   const longitude = Number(school?.longitude);
   const url = `https://www.openstreetmap.org/export/embed.html?bbox=${longitude},${latitude},${longitude},${latitude}&layer=mapnik&marker=${latitude},${longitude}`;
@@ -63,8 +62,24 @@ function SchoolpageView() {
   const [savedSchools, setSavedSchools] = React.useState([]);
   const [reviews, setReviews] = React.useState([]);
   const [loggedIn, setLoggedIn] = React.useState(false);
+  
+  const [testScores, setTestScores] = React.useState([]);
 
-
+  React.useEffect(() => {
+    const schoolName = school?.school_name;
+    if (schoolName) {
+      const url = `https://data.cityofnewyork.us/resource/2h3w-9uj9.json?school_name=${schoolName}&year=2019`;
+      fetch(url)
+        .then(response => response.json())
+        .then(data => {
+          setTestScores(data);
+        })
+        .catch(error => {
+          console.error(error);
+        });
+    };
+  }, [school]);
+  
   React.useEffect(() => {
     onAuthStateChanged(auth, (user) => {
       if (user) {
@@ -238,6 +253,11 @@ function SchoolpageView() {
     programs.scrollIntoView({ behavior: 'smooth' });
   }
 
+  const handleTestScoresClick = () => {
+    const programs = document.getElementById('aca-testscores');
+    programs.scrollIntoView({ behavior: 'smooth' });
+  }
+
   const handleSave = () => {
     if (auth.currentUser != null || undefined) {
       if(!savedSchools.includes(school.school_name)) {
@@ -279,6 +299,67 @@ function SchoolpageView() {
     }
   });
   
+
+  const algebraRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Common Core Algebra" &&
+      
+      score.category === "English Proficient";
+  });
+  const algebraMeanScore = algebraRegentsScores[0]?.mean_score;
+ 
+  const algebra2RegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Common Core Algebra2" &&
+      score.category === "English Proficient";
+  });
+  const algebra2MeanScore = algebra2RegentsScores[0]?.mean_score;
+
+  const englishRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Common Core English" &&
+      score.category === "English Proficient";
+  });
+  const englishMeanScore = englishRegentsScores[0]?.mean_score;
+
+  const geometryRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Common Core Geometry" &&
+      score.category === "English Proficient";
+  });
+  const geometryMeanScore = geometryRegentsScores[0]?.mean_score;
+
+  const globalhistoryRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Global History and Geography" &&
+      score.category === "English Proficient";
+  });
+  const globalhistoryMeanScore = globalhistoryRegentsScores[0]?.mean_score;
+
+  const livingEnvironRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Living Environment" &&
+      score.category === "English Proficient";
+  });
+  const livingEnvironMeanScore = livingEnvironRegentsScores[0]?.mean_score;
+
+  const chemistryRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Physical Settings/Chemistry" &&
+      score.category === "English Proficient";
+  });
+  const chemistryMeanScore = chemistryRegentsScores[0]?.mean_score;
+
+  const earthScienceRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Physical Settings/Earth Science" &&
+      score.category === "English Proficient";
+  });
+  const earthScienceMeanScore = earthScienceRegentsScores[0]?.mean_score;
+
+  const physicsRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "Physical Settings/Physics" &&
+      score.category === "English Proficient";
+  });
+  const physicsMeanScore = physicsRegentsScores[0]?.mean_score;
+
+  const USHistoryRegentsScores = testScores.filter(score => {
+    return score.regents_exam === "U.S. History and Government" &&
+      score.category === "English Proficient";
+  });
+  const USHistoryMeanScore = USHistoryRegentsScores[0]?.mean_score;
 
   return (
     <>
@@ -412,6 +493,9 @@ function SchoolpageView() {
               </ListItemButton>
               <ListItemButton sx={{ pl: 0 }} onClick={handleProgramsClick}>
                 Programs Offered
+              </ListItemButton>
+              <ListItemButton sx={{ pl: 0 }} onClick={handleTestScoresClick}>
+                Test Scores
               </ListItemButton>
             </List>
             <Typography variant="h6" sx={{ mb: 2 }}>Student Support</Typography>
@@ -761,6 +845,23 @@ function SchoolpageView() {
                 )}
               </List>
             </Box>
+{/*Test Scores*/}
+            <Box id="aca-testscores" className="middle-container academics">
+              <h3>Academics</h3>
+              <h2>Test Scores</h2>
+              <h4>Regents Exams</h4>
+              <p>Algebra I:  {algebraMeanScore}</p>
+              <p>Algebra II: {algebra2MeanScore} </p>
+              <p>English: {englishMeanScore} </p>
+              <p>Geometry: {geometryMeanScore} </p>
+              <p>Global History: {globalhistoryMeanScore} </p>
+              <p>U.S. History: {USHistoryMeanScore}</p>
+              <p>Living Environment:  {livingEnvironMeanScore}</p>
+              <p>Earth Science: {earthScienceMeanScore} </p>
+              <p>Chemistry: {chemistryMeanScore} </p>
+              <p>Physics: {physicsMeanScore} </p>
+            </Box>
+
           </Box>
         </Grid>
         <Tooltip title="Save School">

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -1055,10 +1055,10 @@ function SchoolpageView() {
                       <HorizontalScoreBar examName="Earth Science" value={Math.round(earthScienceMeanScore)} stateAverage={74}  />
                     }
                     {chemistryMeanScore && chemistryMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} stateAverage={73}  />
+                      <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} stateAverage={73}/>
                     }
                     {physicsMeanScore && physicsMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} stateAverage={78} />
+                      <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} stateAverage={78}/> 
                     }
                   </TableBody>
                 </Table>
@@ -1127,7 +1127,7 @@ function SchoolpageView() {
                   </Table>
                 </div>
               )}
-  {/*Will Route to Stats page*/}
+  {/*Will Route to Stats page soon*/}
               <Link
                 to={`/map/${encodeURIComponent(school.school_name)}`}   
                 state={{ latitude, longitude, school }}

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -14,7 +14,9 @@ import {
   IconButton,
   Tooltip,
   Table, 
-  TableBody
+  TableBody,
+  TableRow,
+  TableCell,
 } from "@mui/material";
 import Chip from "@mui/material/Chip";
 import {
@@ -70,7 +72,7 @@ function SchoolpageView() {
   const [loggedIn, setLoggedIn] = React.useState(false);
 
   const [testScores, setTestScores] = React.useState([]);
-
+  const [apScores, setAPScores] = React.useState([]);
   React.useEffect(() => {
     const schoolDbn = school?.dbn;
     if (schoolDbn) {
@@ -79,6 +81,21 @@ function SchoolpageView() {
         .then(response => response.json())
         .then(data => {
           setTestScores(data);
+        })
+        .catch(error => {
+          console.error(error);
+        });
+    };
+  }, [school]);
+
+  React.useEffect(() => {
+    const schoolDbn = school?.dbn;
+    if (schoolDbn) {
+      const url = `https://data.cityofnewyork.us/resource/9ct9-prf9.json?dbn=${schoolDbn}`;
+      fetch(url)
+        .then(response => response.json())
+        .then(data => {
+          setAPScores(data);
         })
         .catch(error => {
           console.error(error);
@@ -436,6 +453,13 @@ function SchoolpageView() {
     }
   });
   const italianMeanScore = italianRegentsScores[0]?.mean_score;
+  
+  const apExamsPassed = apScores[0]?.num_of_ap_exams_passed;
+  const apTotalExams = apScores[0]?.num_of_ap_total_exams_taken;
+  const apTestTakers = apScores[0]?.num_of_ap_test_takers;
+
+  const apPassRate = Math.round((Number(apExamsPassed) / Number(apTotalExams)) * 100); 
+  const apEnrollment = Math.round((Number(apTestTakers) / Number(school?.total_students)) * 100);
 
   const Label = ({ text, backcolor, color }) => {
     return (
@@ -1020,7 +1044,25 @@ function SchoolpageView() {
                   </TableBody>
                 </Table>
               </Box>
-
+              {((apTestTakers && apTestTakers !== "s") ||
+                (apExamsPassed && apExamsPassed !== "s") ||
+                (apTotalExams && apTotalExams !== "s")) && (
+                  <h4>Advanced Placement Exams</h4>
+                )}
+              <Table>
+                {apExamsPassed !== "s" && apTotalExams !== "s" && (
+                  <TableCell sx={{ border: 'none' }}>
+                    <Typography variant="body1">AP Exam Pass Rate</Typography>
+                    <Typography variant="h2" sx={{ fontSize: '3rem' }}>{apPassRate}%</Typography>
+                  </TableCell>
+                )}
+                {apTestTakers !== "s" && (
+                  <TableCell sx={{ border: 'none' }}>
+                    <Typography variant="body1">AP Exam Enrollment</Typography>
+                    <Typography variant="h2" sx={{ fontSize: '3rem' }}>~{apEnrollment}%</Typography>
+                  </TableCell>
+                )}
+              </Table>
             </Box>
           </Box>
         </Grid>

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -62,13 +62,13 @@ function SchoolpageView() {
   const [savedSchools, setSavedSchools] = React.useState([]);
   const [reviews, setReviews] = React.useState([]);
   const [loggedIn, setLoggedIn] = React.useState(false);
-  
+
   const [testScores, setTestScores] = React.useState([]);
 
   React.useEffect(() => {
-    const schoolName = school?.school_name;
-    if (schoolName) {
-      const url = `https://data.cityofnewyork.us/resource/2h3w-9uj9.json?school_name=${schoolName}&year=2019`;
+    const schoolDbn = school?.dbn;
+    if (schoolDbn) {
+      const url = `https://data.cityofnewyork.us/resource/2h3w-9uj9.json?school_dbn=${schoolDbn}&year=2019`;
       fetch(url)
         .then(response => response.json())
         .then(data => {
@@ -631,7 +631,7 @@ function SchoolpageView() {
                 )}
               </List>
               <Link
-                to={`/map/${school.school_name}`}
+                to={`/map/${encodeURIComponent(school.school_name)}`}
                 state={{ latitude, longitude, school }}
                 style={{ color: "#16A1DD" }}
               >

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -12,8 +12,11 @@ import {
   Typography,
   ListItemIcon,
   IconButton,
-  Tooltip
+  Tooltip,
+  Table, 
+  TableBody
 } from "@mui/material";
+import Chip from "@mui/material/Chip";
 import {
   LocationOn,
   Phone,
@@ -51,7 +54,7 @@ import { SiMoleculer } from 'react-icons/si/index.js';
 import { GoComment } from 'react-icons/go/index.js';
 
 import HorizontalScoreBar from "../HorizontalScoreBar";
-import { Table, TableBody} from '@mui/material';
+
 
 function SchoolpageView() {
   const location = useLocation();
@@ -301,93 +304,155 @@ function SchoolpageView() {
       document.querySelector('.left-container').classList.remove('fixed-left-container');
     }
   });
-  
+
+  const isInternational = school?.international === "1"; 
+  const isSpecialized = school?.specialized === "1"; 
+  const isTransfer = school?.transfer === "1";
+  const isPTech = school?.ptech === "1";
+  const isEarlyCollege = school?.earlycollege === "1";
 
   const algebraRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Common Core Algebra" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Common Core Algebra" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Common Core Algebra" && score.category === "English Proficient";
+    }
   });
   const algebraMeanScore = algebraRegentsScores[0]?.mean_score;
  
   const algebra2RegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Common Core Algebra2" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Common Core Algebra2" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Common Core Algebra2" && score.category === "English Proficient";
+    }
   });
   const algebra2MeanScore = algebra2RegentsScores[0]?.mean_score;
 
   const englishRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Common Core English" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Common Core English" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Common Core English" && score.category === "English Proficient";
+    }
   });
   const englishMeanScore = englishRegentsScores[0]?.mean_score;
 
   const geometryRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Common Core Geometry" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Common Core Geometry" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Common Core Geometry" && score.category === "English Proficient";
+    }
   });
   const geometryMeanScore = geometryRegentsScores[0]?.mean_score;
 
   const globalhistoryRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Global History and Geography" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Global History and Geography" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Global History and Geography" && score.category === "English Proficient";
+    }
   });
   const globalhistoryMeanScore = globalhistoryRegentsScores[0]?.mean_score;
 
   const livingEnvironRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Living Environment" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Living Environment" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Living Environment" && score.category === "English Proficient";
+    }
   });
   const livingEnvironMeanScore = livingEnvironRegentsScores[0]?.mean_score;
 
   const chemistryRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Physical Settings/Chemistry" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Physical Settings/Chemistry" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Physical Settings/Chemistry" && score.category === "English Proficient";
+    }
   });
   const chemistryMeanScore = chemistryRegentsScores[0]?.mean_score;
 
   const earthScienceRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Physical Settings/Earth Science" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Physical Settings/Earth Science" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Physical Settings/Earth Science" && score.category === "English Proficient";
+    }
   });
   const earthScienceMeanScore = earthScienceRegentsScores[0]?.mean_score;
 
   const physicsRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Physical Settings/Physics" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Physical Settings/Physics" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Physical Settings/Physics" && score.category === "English Proficient";
+    }
   });
   const physicsMeanScore = physicsRegentsScores[0]?.mean_score;
 
   const USHistoryRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "U.S. History and Government" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "U.S. History and Government" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "U.S. History and Government" && score.category === "English Proficient";
+    }
   });
   const USHistoryMeanScore = USHistoryRegentsScores[0]?.mean_score;
 
   const spanishRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Spanish" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Spanish" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Spanish" && score.category === "English Proficient";
+    }
   });
   const spanishMeanScore = spanishRegentsScores[0]?.mean_score;
 
   const frenchRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "French" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "French" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "French" && score.category === "English Proficient";
+    }
   });
   const frenchMeanScore = frenchRegentsScores[0]?.mean_score;
 
   const chineseRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Chinese" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Chinese" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Chinese" && score.category === "English Proficient";
+    }
   });
   const chineseMeanScore = chineseRegentsScores[0]?.mean_score;
 
   const italianRegentsScores = testScores.filter(score => {
-    return score.regents_exam === "Italian" &&
-      score.category === "English Proficient";
+    if (isInternational) {
+      return score.regents_exam === "Italian" && score.category === "ELL";
+    } else {
+      return score.regents_exam === "Italian" && score.category === "English Proficient";
+    }
   });
   const italianMeanScore = italianRegentsScores[0]?.mean_score;
 
-
+  const Label = ({ text, backcolor, color }) => {
+    return (
+      <Chip
+        label={text}
+        sx={{
+          backgroundColor: backcolor,
+          color: color,
+          fontWeight: "bold",
+          fontSize: "14px",
+          borderRadius: "15px",
+          border: `2.5px solid ${color}`,
+          marginLeft: "0.5em",
+        }}
+      />
+    );
+  };
 
   return (
     <>
@@ -485,6 +550,23 @@ function SchoolpageView() {
                   {school?.finalgrades.slice(0, 1)}-
                   {school?.finalgrades.slice(2 - 4)}
                 </strong>
+              </span>
+              <span style={{ marginLeft: "6em" }}>
+                {isSpecialized && (
+                  <Label text="Specialized" backcolor="#DAFBE2" color="#177F3C" />
+                )}
+                {isInternational && (
+                  <Label text="International" backcolor="#FBEFFE" color="#8655DC" />
+                )}
+                {isTransfer && (
+                  <Label text="Transfer" backcolor="#FFF8C7" color="#9A6711" />
+                )}
+                {isPTech && (
+                  <Label text="P-Tech" backcolor="#FFF1E5" color="#BD4C09" />
+                )}
+                {isEarlyCollege && (
+                  <Label text="Early College" backcolor="#FFEFF7" color="#C03987" />
+                )}
               </span>
             </Typography>
           </Box>
@@ -873,7 +955,7 @@ function SchoolpageView() {
                 )}
               </List>
             </Box>
-            {/*Test Scores*/}
+{/*Test Scores*/}
             <Box id="aca-testscores" className="middle-container academics">
               <h3>Academics</h3>
               <h2>Test Scores</h2>
@@ -914,7 +996,12 @@ function SchoolpageView() {
                   </TableBody>
                 </Table>
               </Box>
-              <h4>Language (LOTE) Exams</h4>
+              {((spanishMeanScore && spanishMeanScore !== "s") ||
+                (frenchMeanScore && frenchMeanScore !== "s") ||
+                (italianMeanScore && italianMeanScore !== "s") ||
+                (chineseMeanScore && chineseMeanScore !== "s")) && (
+                  <h4>Language (LOTE) Exams</h4>
+                )}
               <Box sx={{ width: "100%" }}>
                 <Table>
                   <TableBody>

--- a/frontend/src/components/views/SchoolpageView.jsx
+++ b/frontend/src/components/views/SchoolpageView.jsx
@@ -1031,34 +1031,34 @@ function SchoolpageView() {
                 <Table>
                   <TableBody>
                     {algebraMeanScore && algebraMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Algebra I" value={Math.round(algebraMeanScore)} />
+                      <HorizontalScoreBar examName="Algebra I" value={Math.round(algebraMeanScore)} stateAverage={73}  />
                     }
                     {algebra2MeanScore && algebra2MeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Algebra II" value={Math.round(algebra2MeanScore)} />
+                      <HorizontalScoreBar examName="Algebra II" value={Math.round(algebra2MeanScore)} stateAverage={76}  />
                     }
                     {geometryMeanScore && geometryMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Geometry" value={Math.round(geometryMeanScore)} />
+                      <HorizontalScoreBar examName="Geometry" value={Math.round(geometryMeanScore)} stateAverage={73}  />
                     }
                     {englishMeanScore && englishMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="English" value={Math.round(englishMeanScore)} />
+                      <HorizontalScoreBar examName="English" value={Math.round(englishMeanScore)} stateAverage={77}  />
                     }
                     {globalhistoryMeanScore && globalhistoryMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Global History" value={Math.round(globalhistoryMeanScore)} />
+                      <HorizontalScoreBar examName="Global History" value={Math.round(globalhistoryMeanScore)} stateAverage={73}  />
                     }
                     {USHistoryMeanScore && USHistoryMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="U.S. History" value={Math.round(USHistoryMeanScore)} />
+                      <HorizontalScoreBar examName="U.S. History" value={Math.round(USHistoryMeanScore)} stateAverage={78}  />
                     }
                     {livingEnvironMeanScore && livingEnvironMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Living Environment" value={Math.round(livingEnvironMeanScore)} />
+                      <HorizontalScoreBar examName="Living Environment" value={Math.round(livingEnvironMeanScore)} stateAverage={75}  />
                     }
                     {earthScienceMeanScore && earthScienceMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Earth Science" value={Math.round(earthScienceMeanScore)} />
+                      <HorizontalScoreBar examName="Earth Science" value={Math.round(earthScienceMeanScore)} stateAverage={74}  />
                     }
                     {chemistryMeanScore && chemistryMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} />
+                      <HorizontalScoreBar examName="Chemistry" value={Math.round(chemistryMeanScore)} stateAverage={73}  />
                     }
                     {physicsMeanScore && physicsMeanScore !== "s" &&
-                      <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} />
+                      <HorizontalScoreBar examName="Physics" value={Math.round(physicsMeanScore)} stateAverage={78} />
                     }
                   </TableBody>
                 </Table>
@@ -1093,20 +1093,20 @@ function SchoolpageView() {
                   <h4>Advanced Placement Exams</h4>
                 )}
               <Table>
-                {apExamsPassed !== "s" && apTotalExams !== "s" && (
+                {apExamsPassed && apExamsPassed !== "s" && apTotalExams && apTotalExams !== "s" && (
                   <TableCell sx={{ border: 'none' }}>
                     <Typography variant="body1">AP Exam Pass Rate</Typography>
                     <Typography variant="h2">{apPassRate}%</Typography>
                   </TableCell>
                 )}
-                {apTestTakers !== "s" && (
+                {apTestTakers && apTestTakers !== "s" &&(
                   <TableCell sx={{ border: 'none' }}>
                     <Typography variant="body1">AP Exam Enrollment</Typography>
                     <Typography variant="h2">~{apEnrollment}%</Typography>
                   </TableCell>
                 )}
               </Table>
-              {satScoresAvailable && (
+              {satScoresAvailable && satCriticalReading != null && satWriting != null && satMath != null && (
                 <div>
                   <h4>SAT Scores</h4>
                   <Table>
@@ -1127,7 +1127,7 @@ function SchoolpageView() {
                   </Table>
                 </div>
               )}
-    {/*Will Route to Stats page*/}
+  {/*Will Route to Stats page*/}
               <Link
                 to={`/map/${encodeURIComponent(school.school_name)}`}   
                 state={{ latitude, longitude, school }}


### PR DESCRIPTION
SchoolpageView.jsx - added Test Score data 
- Regents scores for 2019 only with horizontal bar 
- fixed routing for schools with a "/" in their name for map page
- added LOTE exam data
- added AP scores, added SAT scores (converted it from 2400 to 1600 scale)
- added special designation labels if a high school is: specialized, international, transfer, ptech, or early college
- changed the Click for More Map and Direction button to the bottom of the container 
- added a More about school's test score data button (currently routes to map page but it will route to stats page)


HorizontalScoreBar - handles the regents horizontal bar charts displayed in schoolpageview
- creates Table rows/cells with their respective exam name, exam score, and bar chart
- has a tooltip to display the state averages for that exam - has page resizing accommodation 
- sets bar chart colors depending on the state average - 
-More than 15 points less than the state average - display red
-within 15 points less than the state average - display yellow
-within 15 points including the state average - display light green
-greater than 15 points above the state average - display darker green 
Will add a hover including this information for users

LiveSearch.jsx - fixed routing for schools with a "/" in their name for schoolpageview


App.css - added some styling for the tooltip and its pointer
